### PR TITLE
Optimize access to _overflow_count from the ISR

### DIFF
--- a/eRCaGuy_Timer2_Counter.cpp
+++ b/eRCaGuy_Timer2_Counter.cpp
@@ -113,13 +113,16 @@ Additional Resources:
 
 #include "eRCaGuy_Timer2_Counter.h"
 
+//define the static class property
+volatile unsigned long eRCaGuy_Timer2_Counter::_overflow_count;
+
 //pre-instantiate an object of this library class, for use by the ISR; call it "timer2"
 eRCaGuy_Timer2_Counter timer2;
 
 //Interrupt Service Routine (ISR) for when Timer2's counter overflows; this will occur every 128us
 ISR(TIMER2_OVF_vect) //Timer2's counter has overflowed 
 {
-  timer2.increment_overflow_count(); //increment the timer2 overflow counter
+  eRCaGuy_Timer2_Counter::_overflow_count++; //increment the timer2 overflow counter
 }
 
 //define class constructor method
@@ -219,13 +222,3 @@ void eRCaGuy_Timer2_Counter::overflow_interrupt_on()
 //  TIMSK2 |= 0b00000001; //enable Timer2 overflow interrupt. (by making the right-most bit in TIMSK2 a 1); see datasheet pg. 159-160
   TIMSK2 |= _BV(TOIE2); //alternate code to do the above; see here for use of _BV: http://194.81.104.27/~brian/microprocessor/BVMacro.pdf 
 }
-
-//Increment overflow counter
-void eRCaGuy_Timer2_Counter::increment_overflow_count()
-{
-  _overflow_count++;
-}
-  
-  
-
-

--- a/eRCaGuy_Timer2_Counter.h
+++ b/eRCaGuy_Timer2_Counter.h
@@ -56,6 +56,9 @@ GS: *************NOTE TO SELF************: I referred to the TimerOne Library (h
  #include <WProgram.h>
 #endif
 
+//this has to be declared in order to make it "friend" below
+extern "C" void TIMER2_OVF_vect();
+
 class eRCaGuy_Timer2_Counter
 {
   public:
@@ -73,7 +76,6 @@ class eRCaGuy_Timer2_Counter
 	void unsetup();
 	void overflow_interrupt_off();
 	void overflow_interrupt_on();
-	void increment_overflow_count();
 	
 	//public variables:
 	//N/A
@@ -83,7 +85,8 @@ class eRCaGuy_Timer2_Counter
 	//N/A
     //Declare private variables (ie: "member variables," or variables which are members of and accessible by this class only):
 	//volatile (used in ISRs)
-	volatile unsigned long _overflow_count; //Timer2 overflow counter; updated in ISR, so must be declared volatile (see here: http://arduino.cc/en/Reference/Volatile)
+	volatile static unsigned long _overflow_count; //Timer2 overflow counter; updated in ISR, so must be declared volatile (see here: http://arduino.cc/en/Reference/Volatile)
+	friend void TIMER2_OVF_vect(); //let the ISR access _overflow_count, despite it being a private member
 	  //GS: for more info on static class members, see here: http://www.tutorialspoint.com/cplusplus/cpp_static_members.htm (or PDF pg. 148-149)
 	unsigned long _total_count; //Timer2 total counter
 	byte _tccr2a_save; //will be used to backup default settings


### PR DESCRIPTION
Making this counter a static (rather than per-instance) class member allows the compiler to access it using direct (instead of indirect) load/store instructions. This saves the instructions needed to save, set and restore a pointer register, and makes the ISR shorter by 6&nbsp;instructions and 10&nbsp;CPU cycles. Even though it is not a huge improvement, a small speed-up can count within an ISR.

Note that `TIMER2_OVF_vect()` had to be declared a “friend” method of the class in order to be able to access the counter, which is private. An alternative would be to make the counter either a public class member or a “static” (as in “static linkage”) global variable of eRCaGuy\_Timer2\_Counter.cpp.

The gain in instructions and CPU cycles was determined by disassembling the provided example display\_time\_elapsed, compiled for an Uno with Arduino&nbsp;1.8.13.