### PR TITLE
Remove unused class member _total_count

### DIFF
--- a/eRCaGuy_Timer2_Counter.cpp
+++ b/eRCaGuy_Timer2_Counter.cpp
@@ -127,7 +127,6 @@ eRCaGuy_Timer2_Counter::eRCaGuy_Timer2_Counter()
 {
   //initialize member variables
   _overflow_count = 0;
-  _total_count = 0;
 }
 
 //setup_T2() --Configure Timer2
@@ -170,7 +169,7 @@ unsigned long eRCaGuy_Timer2_Counter::get_count()
     _overflow_count++; //force the overflow count to increment
     TIFR2 |= 0b00000001; //reset Timer2 overflow flag since we just manually incremented above; see datasheet pg. 160; this prevents execution of Timer2's overflow ISR
   }
-  _total_count = _overflow_count*256 + tcnt2_save; //get total Timer2 count
+  unsigned long _total_count = _overflow_count*256 + tcnt2_save; //get total Timer2 count
   //interrupts(); //allow interrupts again; [updated 20140709] <--WARNING, DO ****NOT**** USE THIS METHOD AFTERALL, OR ELSE IT WILL RE-ENABLE GLOBAL INTERRUPTS IF YOU CALL THIS FUNCTION
                   //DURING AN INTERRUPT SERVICE ROUTINE, THEREBY CAUSING NESTED INTERRUPTS, WHICH CAN REALLY SCREW THINGS UP.
   SREG = SREG_old; //use this method instead, to re-enable interrupts if they were enabled before, or to leave them disabled if they were disabled before
@@ -187,7 +186,6 @@ float eRCaGuy_Timer2_Counter::get_micros()
 void eRCaGuy_Timer2_Counter::reset()
 {
   _overflow_count = 0; //reset overflow counter
-  _total_count = 0; //reset total counter
   TCNT2 = 0; //reset Timer2 counter
   TIFR2 |= 0b00000001; //reset Timer2 overflow flag; see datasheet pg. 160; this prevents an immediate execution of Timer2's overflow ISR
 }

--- a/eRCaGuy_Timer2_Counter.h
+++ b/eRCaGuy_Timer2_Counter.h
@@ -85,7 +85,6 @@ class eRCaGuy_Timer2_Counter
 	//volatile (used in ISRs)
 	volatile unsigned long _overflow_count; //Timer2 overflow counter; updated in ISR, so must be declared volatile (see here: http://arduino.cc/en/Reference/Volatile)
 	  //GS: for more info on static class members, see here: http://www.tutorialspoint.com/cplusplus/cpp_static_members.htm (or PDF pg. 148-149)
-	unsigned long _total_count; //Timer2 total counter
 	byte _tccr2a_save; //will be used to backup default settings
 	byte _tccr2b_save; //will be used to backup default settings
 };


### PR DESCRIPTION
This member was only used in the `get_count()` method, right after being set. Making it a local variable of `get_count()` makes the class 40% smaller and the method slightly faster. It also speeds-up the constructor and the `reset()` method.