### PR TITLE
Avoid race condition on reset()

### DIFF
--- a/eRCaGuy_Timer2_Counter.cpp
+++ b/eRCaGuy_Timer2_Counter.cpp
@@ -186,10 +186,12 @@ float eRCaGuy_Timer2_Counter::get_micros()
 //reset Timer2's counters
 void eRCaGuy_Timer2_Counter::reset()
 {
+  TCCR2B = 0; //stop the timer
   _overflow_count = 0; //reset overflow counter
   _total_count = 0; //reset total counter
   TCNT2 = 0; //reset Timer2 counter
   TIFR2 |= 0b00000001; //reset Timer2 overflow flag; see datasheet pg. 160; this prevents an immediate execution of Timer2's overflow ISR
+  TCCR2B = _BV(CS21); //restart the timer at F_CPU/8
 }
 
 //undo configuration changes for Timer2


### PR DESCRIPTION
The `reset()` method suffered from a race condition: if the timer overflows after `_overflow_count = 0;` and before `TCNT2 = 0;`, the member `_overflow_count` ended up being 1. This is fixed by performing the reset with the timer stopped.

An alternative fix would be to move `TCNT2 = 0;` to the start of the method, and hope that no overly-long ISR would delay us by more than 128&nbsp;µs, which seems like a reasonable expectation. The provided implementation was chosen in order to avoid `TCNT2` incrementing while the method executes.