### PR TITLE
Optimize addition in get_count()

### DIFF
--- a/eRCaGuy_Timer2_Counter.cpp
+++ b/eRCaGuy_Timer2_Counter.cpp
@@ -170,7 +170,7 @@ unsigned long eRCaGuy_Timer2_Counter::get_count()
     _overflow_count++; //force the overflow count to increment
     TIFR2 |= 0b00000001; //reset Timer2 overflow flag since we just manually incremented above; see datasheet pg. 160; this prevents execution of Timer2's overflow ISR
   }
-  _total_count = _overflow_count*256 + tcnt2_save; //get total Timer2 count
+  _total_count = _overflow_count*256 | tcnt2_save; //get total Timer2 count
   //interrupts(); //allow interrupts again; [updated 20140709] <--WARNING, DO ****NOT**** USE THIS METHOD AFTERALL, OR ELSE IT WILL RE-ENABLE GLOBAL INTERRUPTS IF YOU CALL THIS FUNCTION
                   //DURING AN INTERRUPT SERVICE ROUTINE, THEREBY CAUSING NESTED INTERRUPTS, WHICH CAN REALLY SCREW THINGS UP.
   SREG = SREG_old; //use this method instead, to re-enable interrupts if they were enabled before, or to leave them disabled if they were disabled before


### PR DESCRIPTION
When translating

```cpp
_total_count = _overflow_count*256 + tcnt2_save;
```

the compiler (avr-g++ 7.3.0) does not optimize the addition. Replacing it with a bitwise “or” saves 3&nbsp;instructions and 3&nbsp;CPU cycles. Note that the multiplication _is_ optimized into a bit shift (register moves).

Merging this with #6 (Remove unused class member \_total\_count) makes a total saving of 7&nbsp;instructions and 11&nbsp;cycles in `get_count()`. We can do better, but that will be for another day.